### PR TITLE
Show venue as TBA when undefined

### DIFF
--- a/_includes/_load_events_feed.html
+++ b/_includes/_load_events_feed.html
@@ -16,7 +16,7 @@
       var templateData = {
         name: name,
         date: dateWrapper.format('dddd, MMM Do, HH:MM'),
-        venue: cal_event.venue.name,
+        venue: cal_event.venue ? cal_event.venue.name : "TBA",
         link: cal_event.event_url
       };
       html += OTS.template('event', templateData);


### PR DESCRIPTION
When the venue is not set, the Meetup API seems to omit the `venue` key wholesale.  This blows up with an `TypeError: Cannot read property 'name' of undefined`.
