### PR TITLE
Defer to Python portal

### DIFF
--- a/material.md
+++ b/material.md
@@ -12,12 +12,7 @@ All OpenTechSchool Material is open sourced under the [Creative Commons ShareAli
 
 ### Python
 
- * [Beginning Python with turtles](http://opentechschool.github.io/python-beginners/en/)
- * [Introduction to Data Processing](http://opentechschool.github.io/python-data-intro/)
- * [Building a webapp with Django (Marcador)](http://django-marcador.keimlink.de/) \[[Sources](https://bitbucket.org/keimlink/django-marcador)\]
- * [Websites with Flask](http://opentechschool.github.io/python-flask/) \[[Corresponding code](https://github.com/OpenTechSchool/python-flask-code)\] \[[Example instance](http://python-flask-code.herokuapp.com/)\]
- * BioPython: [Help Material](https://github.com/OpenTechSchool/biopython/tree/material) for [Rosalind challenges](http://rosalind.info)
- * [Material Discussion Page](https://github.com/OpenTechSchool/python/wiki)
+**See our [Python portal](http://python.opentechschool.org/) for all material,** or [discuss it](https://github.com/OpenTechSchool/python/wiki) online. 
 
 Have a good idea about a Python Workshop? Join the [python coaches group](https://groups.google.com/a/opentechschool.org/forum/?fromgroups#!forum/coaches.python) and get to it.
 


### PR DESCRIPTION
It does not make sense to curate two lists of material so we should defer to our python.opentechschool.org presence here.
