### PR TITLE
Stop team members from overlapping

### DIFF
--- a/sass/imports/_main.scss
+++ b/sass/imports/_main.scss
@@ -387,8 +387,8 @@ ul.switch_lang {
   height: 8em;
   text-align: center;
     &.member {
-          height: 220px !important; 
-          min-height: 220px; 
+          height: 240px !important;
+          min-height: 240px;
     }
   }
   > li.join {

--- a/sass/imports/_main.scss
+++ b/sass/imports/_main.scss
@@ -2,6 +2,8 @@
 /* ! Shared styles, OTS branding */
 /* ========================================== */
 
+@import "compass/utilities/general/min";
+
 body {
   margin: 0;
   font-size: 75%;
@@ -382,13 +384,10 @@ ul.switch_lang {
 /* List of OTS members, extends float list. Includes image and links. */
 .team_list {
   > li {
-  min-height: 8em;
-  height:auto !important;
-  height: 8em;
-  text-align: center;
+    @include min-height(8em);
+    text-align: center;
     &.member {
-          height: 240px !important;
-          min-height: 240px;
+      @include min-height(240px);
     }
   }
   > li.join {
@@ -430,9 +429,7 @@ ul.switch_lang {
   }
   p {
     font-size: .714em;
-    min-height: 6em;
-    height:auto !important;
-    height: 6em;
+    @include min-height(6em);
   }
 }
 
@@ -582,9 +579,7 @@ footer a:focus {
   // color: #FFF;
   position: relative;
   width: 100%;
-  min-height: 400px;
-  height:auto !important;
-  height: 400px;
+  @include min-height(400px);
   header {
     overflow: hidden;
   }

--- a/stylesheets/screen.css
+++ b/stylesheets/screen.css
@@ -157,7 +157,7 @@ ul.switch_lang li.active a { background-color: #085987; color: #FFF; }
 
 /* List of OTS members, extends float list. Includes image and links. */
 .team_list > li { min-height: 8em; height: auto !important; height: 8em; text-align: center; }
-.team_list > li.member { height: 220px !important; min-height: 220px; }
+.team_list > li.member { min-height: 240px; height: auto !important; height: 240px; }
 .team_list > li.join div { display: inline-block; border: 5px solid #eee; border-radius: 100%; width: 190px; height: 190px; position: relative; }
 .team_list > li.join div form { position: absolute; top: 50%; margin-top: -13px; font-size: 90%; }
 .team_list > li.join div form input.subscribe_email { width: 180px; height: 22px; padding: 2px; margin-bottom: 3px; border: 1px solid gray; }


### PR DESCRIPTION
Currently, team members images overlap the emails of the members from the previous line.  Tested in Firefox 24.4.0 and Chromium 32.0.1700.123.
