### PR TITLE
Fixed broken lists

### DIFF
--- a/handbooks/workshops/organisers-schedule.md
+++ b/handbooks/workshops/organisers-schedule.md
@@ -22,34 +22,35 @@ Obviously, pick the date with the most coaches being available.  Some coaches wi
 In our experience, you should schedule the event at least two weeks in advance to have some time to promote your workshop and make people aware it is going to happen. If you actually have more than 3 weeks that is amazing, but don't schedule it for a half a year in advance (unless there is a good reason for that) because people will forget they signed up and the turn-up number will be lower.
 
 When scheduling the event, please keep in mind:
- * Out of experience the best time to open signup is on Tuesdays at 6pm. 
- * We usually schedule the event info and start the promotion _before_ signups are opened, at least a day before.  This is in order to ensure we reach as diverse an audience as possible and not only those who are able to check their email every 2 minutes.
-  * Feel free to ignore this if you do not expect to have a waiting list.  It might actually discourage people if they have to come back to actually sign up and, thus, hurt smaller chapters.
- * Since this is a free event, the no-show rate is going to be about 20-30% (up to 50% on good weather.)  You can well overbook your capacities usually.
- * Set the number of people able to sign up to the number of coaches which confirmed to come * 4.  So if you have 10 coaches, allow 40 signups.  This allows, bearing the no-show rate in mind, for a 3:1 learner/coach ratio.
-  * If you also track coaches through Meetup, raise the sign up limit to * 5.  This way the coaches can RSVP the event as well.
-  * Do not set the number of slots too high, initially, to create some kind of demand.  You can still raise the limits when there is a waiting list.
- * You might want to close signups a few days before the actual event to make sure communication happens accordingly.
+
+- Out of experience the best time to open signup is on Tuesdays at 6pm.
+- We usually schedule the event info and start the promotion _before_ signups are opened, at least a day before.  This is in order to ensure we reach as diverse an audience as possible and not only those who are able to check their email every 2 minutes.
+- Feel free to ignore this if you do not expect to have a waiting list.  It might actually discourage people if they have to come back to actually sign up and, thus, hurt smaller chapters.
+- Since this is a free event, the no-show rate is going to be about 20-30% (up to 50% on good weather.)  You can well overbook your capacities usually.
+- Set the number of people able to sign up to the number of coaches which confirmed to come * 4.  So if you have 10 coaches, allow 40 signups.  This allows, bearing the no-show rate in mind, for a 3:1 learner/coach ratio.
+- If you also track coaches through Meetup, raise the sign up limit to * 5.  This way the coaches can RSVP the event as well.
+- Do not set the number of slots too high, initially, to create some kind of demand.  You can still raise the limits when there is a waiting list.
+- You might want to close signups a few days before the actual event to make sure communication happens accordingly.
 
 When promoting, also make sure potential coaches know they are invited to come and who to talk to, if they want to. Usually that would be via answering on a public email or to you personally.
 
 Lacking coaches?  Send out a "Call for Coaches" to your Meetup group or local team mailing list, related user groups, relevant newsletters or message boards.  Examples: [blog post](http://blog.opentechschool.org/2013/04/call-for-coaches-hackathon-for-kids.html), [Meetup message](http://www.meetup.com/opentechschool-zurich/messages/boards/thread/34200822), [email](https://groups.google.com/a/opentechschool.org/d/msg/coaches.python/PUM1h_kThQE/uSOkqiDJJYUJ).
 
 ## Two days before signups close
- * You might have more coaches now. Raise the number of signups accordingly.
- * Send email via the Meetup form to the participants who signed up so far, telling them there are more seats available, you are looking forward to seeing you there and to update their RSVP if they can't make it to give others a chance to participate instead. You can find an almost [copy-pasteable example online](/handbooks/workshops/example-before-closing.html).
- * Send an email to your coaches confirming time and place, containing a link to the [Coaches Guide](http://opentechschool.github.io/slides/presentations/coaching/) as well as the learning material. You can find an [example online](/handbooks/workshops/example-coaches-mail.html).
- * You might want to promote the workshop once more, stating you have more open slots now.
+- You might have more coaches now. Raise the number of signups accordingly.
+- Send email via the Meetup form to the participants who signed up so far, telling them there are more seats available, you are looking forward to seeing you there and to update their RSVP if they can't make it to give others a chance to participate instead. You can find an almost [copy-pasteable example online](/handbooks/workshops/example-before-closing.html).
+- Send an email to your coaches confirming time and place, containing a link to the [Coaches Guide](http://opentechschool.github.io/slides/presentations/coaching/) as well as the learning material. You can find an [example online](/handbooks/workshops/example-coaches-mail.html).
+- You might want to promote the workshop once more, stating you have more open slots now.
 
 ## After signups are closed
- * Send the confirmation email to the participants through the Meetup interface. Make sure it contains at least: the place and time, any requirements needed (like "bring a laptop", "install X") and how to get in touch in case they are unable to fulfill those.  Any more specific directions on the venue if needed and other useful material. But keep it short. [An example for you is provided online](/handbooks/workshops/example-after-closing.html).
+- Send the confirmation email to the participants through the Meetup interface. Make sure it contains at least: the place and time, any requirements needed (like "bring a laptop", "install X") and how to get in touch in case they are unable to fulfill those.  Any more specific directions on the venue if needed and other useful material. But keep it short. [An example for you is provided online](/handbooks/workshops/example-after-closing.html).
 
 ## Things to prepare
- - It is always nice to have some good coverage of the event.  If you know someone with a camera or fairly new smartphone, ask them to take some photos.
- - Name badges are useful.  Make sure there is tape, post-its, sticky notes, or some such available at the venue.
- - Bring some paper and pens.  It's almost universally useful to create signs on the fly (wifi credentials, afterparty plans, directions and whatnot.)
- - An offline version of editors, the material and other common material like installers (in case the wifi goes down.)
- - A few extenders if needed.
+- It is always nice to have some good coverage of the event.  If you know someone with a camera or fairly new smartphone, ask them to take some photos.
+- Name badges are useful.  Make sure there is tape, post-its, sticky notes, or some such available at the venue.
+- Bring some paper and pens.  It's almost universally useful to create signs on the fly (wifi credentials, afterparty plans, directions and whatnot.)
+- An offline version of editors, the material and other common material like installers (in case the wifi goes down.)
+- A few extenders if needed.
 
 ## The Workshop itself
 
@@ -65,33 +66,34 @@ Have a quick chat with the coaches, quickly re-iterate how this is going to work
  - If you are working on a food-to-share system set up a place for that as well;  mark it appropriately.
 
 ### Kickoff the event
- - Once the majority of learners is there and set up, do a short and quick welcome speech.
- - Ask how many people know the OpenTechSchool already and/or have been to other events before.  (Make them raise their hands. It sounds cheesy but sets an interactive mood.)
-   * If a bigger group doesn't know what OTS is and does, give a [quick introduction](http://opentechschool.github.io/slides/presentations/about-micro/) and tell them to check the website for more details.
-   * Promote any recurring events such as the Learners Meetup or Continuous Learning Groups.
- - (This is critical!)  Explain the schedule and how the workshop is going to happen:  They are working on their own with the material, the coaches standing around are there to assist, help and support, so instead of getting stuck, they should ask them for help.  If there will be a demo session at the end, tell them about that, too.
- - Make sure you explained the necessaries, like:
-   * how to get back in if you are out (if that is a problem)
-   * where to find the toilets, for all genders
-   * where to get something to drink, when the food will be delivered, that kinda stuff
- - Tell them to take breaks whenever they want. It is important to take breaks. We -- developers -- do breaks all the time.
- - Show the URL to the learners material again. Let them know, that they should work at their own pace and if they are not able to get finished that day that is fine, too, the material is available online all the time. Tell them to get started.
- - And mention that they are very much invited to the next Learners Meetup to show what they've done in this workshop, find other learners, connect and socialise.  Bonus points if you can already share a date.
+- Once the majority of learners is there and set up, do a short and quick welcome speech.
+- Ask how many people know the OpenTechSchool already and/or have been to other events before.  (Make them raise their hands. It sounds cheesy but sets an interactive mood.)
+  * If a bigger group doesn't know what OTS is and does, give a [quick introduction](http://opentechschool.github.io/slides/presentations/about-micro/) and tell them to check the website for more details.
+  * Promote any recurring events such as the Learners Meetup or Continuous Learning Groups.
+- (This is critical!)  Explain the schedule and how the workshop is going to happen:  They are working on their own with the material, the coaches standing around are there to assist, help and support, so instead of getting stuck, they should ask them for help.  If there will be a demo session at the end, tell them about that, too.
+- Make sure you explained the necessaries, like:
+  * how to get back in if you are out (if that is a problem)
+  * where to find the toilets, for all genders
+  * where to get something to drink, when the food will be delivered, that kinda stuff
+- Tell them to take breaks whenever they want. It is important to take breaks. We -- developers -- do breaks all the time.
+- Show the URL to the learners material again. Let them know, that they should work at their own pace and if they are not able to get finished that day that is fine, too, the material is available online all the time. Tell them to get started.
+- And mention that they are very much invited to the next Learners Meetup to show what they've done in this workshop, find other learners, connect and socialise.  Bonus points if you can already share a date.
 
 ### Demo session (optional, but encouraged)
 Often learners come up with amazing and awesome little slightly off-the-path hacks during the workshop. Either planned beforehand or just because so many awesome things happened, you might want to make a small demo session at the end inviting everyone to show their results of the day. Encourage everyone doing something creative to come to the front and show it to the others. It doesn't only give them recognition on their work but also shows the others what awesome things you can do with just a little effort (of peers on a similar knowledge level.)
 
 ### Closing the event
 When the first people pack their stuff or after the Demo, ask for their attention for another minute to:
- - Thank everybody for coming.
- - Ask them to provide feedback.  They'll receive an automatic email from Meetup (asking "how was it") a few days later.  That helps us to improve and build a track record.
- - Encourage them to upload any photos they took to the event page on Meetup.
- - Invite them again to show their hacks and awesome ideas at the next [Learners Meetup](http://www.opentechschool.org/handbooks/learners-meetups.html).
- - Don't forget to thank the sponsor of the venue, food and drinks, if any.
- - Let them know what the rest of the days schedule is (for example if you need to be out at a certain time, but they are free to stick around, or if you are going for drinks or stuff.)
- - And eventually ask for a round of applause for the awesome group of coaches who helped them that day.
- - Ask them to help you clean up and rearrange the tables if you need to do that.  Generally, be a good boy/girl scout and leave the place tidier than you found it.
- - Optionally place some guerilla marketing if you feel the location sponsor would be fine with it.  Meetup has a "Flyer with tear-off tabs" in its "Promote" section.
- - Lock the doors, return the keys.  We want to remain in good standing with our venues.
+
+- Thank everybody for coming.
+- Ask them to provide feedback.  They'll receive an automatic email from Meetup (asking "how was it") a few days later.  That helps us to improve and build a track record.
+- Encourage them to upload any photos they took to the event page on Meetup.
+- Invite them again to show their hacks and awesome ideas at the next [Learners Meetup](http://www.opentechschool.org/handbooks/learners-meetups.html).
+- Don't forget to thank the sponsor of the venue, food and drinks, if any.
+- Let them know what the rest of the days schedule is (for example if you need to be out at a certain time, but they are free to stick around, or if you are going for drinks or stuff.)
+- And eventually ask for a round of applause for the awesome group of coaches who helped them that day.
+- Ask them to help you clean up and rearrange the tables if you need to do that.  Generally, be a good boy/girl scout and leave the place tidier than you found it.
+- Optionally place some guerilla marketing if you feel the location sponsor would be fine with it.  Meetup has a "Flyer with tear-off tabs" in its "Promote" section.
+- Lock the doors, return the keys.  We want to remain in good standing with our venues.
 
 Congratulations, you just organised a great workshop.

--- a/handbooks/workshops/organisers-schedule.md
+++ b/handbooks/workshops/organisers-schedule.md
@@ -25,11 +25,11 @@ When scheduling the event, please keep in mind:
 
 - Out of experience the best time to open signup is on Tuesdays at 6pm.
 - We usually schedule the event info and start the promotion _before_ signups are opened, at least a day before.  This is in order to ensure we reach as diverse an audience as possible and not only those who are able to check their email every 2 minutes.
-- Feel free to ignore this if you do not expect to have a waiting list.  It might actually discourage people if they have to come back to actually sign up and, thus, hurt smaller chapters.
+  * Feel free to ignore this if you do not expect to have a waiting list.  It might actually discourage people if they have to come back to actually sign up and, thus, hurt smaller chapters.
 - Since this is a free event, the no-show rate is going to be about 20-30% (up to 50% on good weather.)  You can well overbook your capacities usually.
 - Set the number of people able to sign up to the number of coaches which confirmed to come * 4.  So if you have 10 coaches, allow 40 signups.  This allows, bearing the no-show rate in mind, for a 3:1 learner/coach ratio.
-- If you also track coaches through Meetup, raise the sign up limit to * 5.  This way the coaches can RSVP the event as well.
-- Do not set the number of slots too high, initially, to create some kind of demand.  You can still raise the limits when there is a waiting list.
+  * If you also track coaches through Meetup, raise the sign up limit to * 5.  This way the coaches can RSVP the event as well.
+  * Do not set the number of slots too high, initially, to create some kind of demand.  You can still raise the limits when there is a waiting list.
 - You might want to close signups a few days before the actual event to make sure communication happens accordingly.
 
 When promoting, also make sure potential coaches know they are invited to come and who to talk to, if they want to. Usually that would be via answering on a public email or to you personally.


### PR DESCRIPTION
Jekyll didn't render two lists in "Workshop Organisers Schedule" due to a missing line break.
