### PR TITLE
berlin: add twitter and facebook link to about

### DIFF
--- a/_cities/berlin.md
+++ b/_cities/berlin.md
@@ -31,4 +31,7 @@ want you to start one in your own city! The venue that supported us from the
 very beginning and where we host our events is the fantastic coworking space,
 [co.up].
 
+<a href="https://twitter.com/OTS_BLN" title="OTS Berlin Twitter" class="ots_icon twitter" style="float:left;">Twitter</a>
+<a href="http://www.facebook.com/opentechschool.berlin" title="OTS Berlin Facebook page" class="ots_icon facebook" style="float:left;">Facebook</a>
+
 [co.up]: http://co-up.de/


### PR DESCRIPTION
currently we don't have any link to facebook (berlin page) and the twitter widget is quite far down in the page
