### PR TITLE
make hamburg team page use data from discourse

### DIFF
--- a/_cities/hamburg.md
+++ b/_cities/hamburg.md
@@ -4,6 +4,7 @@ location: "Hamburg, Germany"
 tagline: "Shipping is our tradition... and so are Franzbrötchen."
 custom_events: ""
 twitter: false
+discourse_group: TeamHamburg
 does:
   workshops
   appsummercamps


### PR DESCRIPTION
Make hamburg team page use data from discourse (like berlin and other chapters).

Team in discourse has been updated so let's use it.
