### PR TITLE
Fixes #233 responsive layout for Discussions on home page

### DIFF
--- a/_sass/_main.scss
+++ b/_sass/_main.scss
@@ -476,15 +476,12 @@ ul.nav {
 
 
 .discussion {
-  width: 75%;
   margin: 0 auto;
   margin-bottom: 0;
 }
 
 .topic {
   padding: 15px 0;
-  width: 50%;
-  display: inline-block;
   vertical-align: top;
   .metadata {
     opacity: 0.6;

--- a/_sass/_mediaqueries.scss
+++ b/_sass/_mediaqueries.scss
@@ -119,6 +119,15 @@
       margin-top: 2.4em;
     }
   }
+
+  .discussion {
+    width: 75%;
+  }
+
+  .topic {
+    width: 50%;
+    display: inline-block;
+  }
 }
 
 


### PR DESCRIPTION
Fixes https://github.com/OpenTechSchool/www.opentechschool.org/issues/233

Made default style mobile first and thus moved current style to media queries for larger screens

![image](https://user-images.githubusercontent.com/892961/46583091-d487db80-ca83-11e8-9008-42a92164d741.png)


**GIF showing mobile responsive nature**
![discussions](https://user-images.githubusercontent.com/892961/46583071-8d014f80-ca83-11e8-860a-994211c65dd8.gif)
