### PR TITLE
Remove Google+ Link from Home

### DIFF
--- a/index.html
+++ b/index.html
@@ -103,7 +103,6 @@ rss_feed: full
           <div class="clearfix">
             <a href="https://www.twitter.com/OpenTechSchool" class="btn"><span class="ots_icon twitter"></span> Twitter</a>
             <a href="http://www.facebook.com/OpenTechSchool" class="btn"><span class="ots_icon facebook"></span> Facebook</a>
-            <a href="https://plus.google.com/b/114834784518588736271/114834784518588736271/posts" class="btn">Google+</a>
           </div>
           <h4>and</h4>
           <div class="clearfix">


### PR DESCRIPTION
…as Google+ is no longer available/out of service