### PR TITLE
Remove Google+ Link from Footer

### DIFF
--- a/_includes/_footer.html
+++ b/_includes/_footer.html
@@ -57,9 +57,6 @@
               <a href="http://discourse.opentechschool.org/">Discourse</a>
             </li>
             <li>
-              <a href="https://plus.google.com/b/114834784518588736271/114834784518588736271/posts">Google+</a>
-            </li>
-            <li>
               <a href="https://groups.google.com/a/opentechschool.org/forum/?fromgroups#!forum/discuss.global">Mailing list</a>
             </li>
             <li>


### PR DESCRIPTION
…because Google+ is dead.